### PR TITLE
fix: remove rule

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -17,7 +17,6 @@ module.exports = {
     'no-shadow': ['error', { builtinGlobals: true, hoist: 'all' }],
     'no-confusing-arrow': 'error',
     'no-duplicate-imports': 'error',
-    'no-restricted-syntax': ['error', 'CatchClause[param=null]'],
     'no-underscore-dangle': 'off',
     'no-unused-expressions': 'off',
     'no-useless-constructor': 'error',


### PR DESCRIPTION
Removes the `'no-restricted-syntax': ['error', 'CatchClause[param=null]']` rule